### PR TITLE
Go solution

### DIFF
--- a/go/marsroverkata/MarsRover.go
+++ b/go/marsroverkata/MarsRover.go
@@ -78,15 +78,39 @@ func (r MarsRover) acceptCommands(commands []Command) {
 }
 
 func (r MarsRover) coordinates() Coordinates {
-	return Coordinates{0, 0}
+	return r.position
 }
 
-func (r MarsRover) forward() {
-
+func (r *MarsRover) forward() {
+	curr := r.position
+	switch r.heading {
+	case N:
+		r.position = Coordinates{curr.x, curr.y - 1}
+	case E:
+		r.position = Coordinates{curr.x + 1, curr.y}
+	case S:
+		r.position = Coordinates{curr.x, curr.y + 1}
+	case W:
+		r.position = Coordinates{curr.x - 1, curr.y}
+	default:
+		panic("I won't know which way I am heading!!")
+	}
 }
 
-func (r MarsRover) backward() {
-
+func (r *MarsRover) backward() {
+	curr := r.position
+	switch r.heading {
+	case N:
+		r.position = Coordinates{curr.x, curr.y + 1}
+	case E:
+		r.position = Coordinates{curr.x - 1, curr.y}
+	case S:
+		r.position = Coordinates{curr.x, curr.y - 1}
+	case W:
+		r.position = Coordinates{curr.x + 1, curr.y}
+	default:
+		panic("I won't know which way I am heading!!")
+	}
 }
 
 func (r *MarsRover) turnRight() {

--- a/go/marsroverkata/MarsRover.go
+++ b/go/marsroverkata/MarsRover.go
@@ -75,7 +75,24 @@ func (r MarsRover) currentLocation() interface{} {
 	return fmt.Sprintf("%d %d %s", r.position.x, r.position.y, r.heading)
 }
 
-func (r MarsRover) acceptCommands(commands []Command) {
+func (r *MarsRover) acceptCommands(commands []Command) {
+	r.showOnGrid() // Show the initial position
+	for i := range commands {
+		switch commands[i] {
+		case B:
+			r.backward()
+		case F:
+			r.forward()
+		case L:
+			r.turnLeft()
+		case R:
+			r.turnRight()
+		default:
+			panic("I don't know that command!!")
+		}
+		fmt.Println(r.position)
+		r.showOnGrid()
+	}
 
 }
 
@@ -102,11 +119,11 @@ func (r *MarsRover) forward() {
 	curr := r.position
 	switch r.heading {
 	case N:
-		r.position = Coordinates{curr.x, curr.y - 1}
+		r.position = Coordinates{curr.x, curr.y + 1}
 	case E:
 		r.position = Coordinates{curr.x + 1, curr.y}
 	case S:
-		r.position = Coordinates{curr.x, curr.y + 1}
+		r.position = Coordinates{curr.x, curr.y - 1}
 	case W:
 		r.position = Coordinates{curr.x - 1, curr.y}
 	default:
@@ -119,11 +136,11 @@ func (r *MarsRover) backward() {
 	curr := r.position
 	switch r.heading {
 	case N:
-		r.position = Coordinates{curr.x, curr.y + 1}
+		r.position = Coordinates{curr.x, curr.y - 1}
 	case E:
 		r.position = Coordinates{curr.x - 1, curr.y}
 	case S:
-		r.position = Coordinates{curr.x, curr.y - 1}
+		r.position = Coordinates{curr.x, curr.y + 1}
 	case W:
 		r.position = Coordinates{curr.x + 1, curr.y}
 	default:
@@ -140,4 +157,9 @@ func (r *MarsRover) turnRight() {
 		newDirection = r.heading + 1
 	}
 	r.heading = newDirection
+}
+
+func (r *MarsRover) showOnGrid() {
+	CurrentGrid.UpdateRoverPosition(r.heading, r.position)
+	CurrentGrid.Draw()
 }

--- a/go/marsroverkata/MarsRover.go
+++ b/go/marsroverkata/MarsRover.go
@@ -13,6 +13,7 @@ const (
 	S
 	W
 )
+
 func (d Direction) String() string {
 	return [...]string{"N", "E", "S", "W"}[d]
 }
@@ -35,8 +36,8 @@ type Obstacle struct {
 }
 
 type Plateau struct {
-	maxX int
-	maxY int
+	maxX      int
+	maxY      int
 	obstacles []Obstacle
 }
 
@@ -46,19 +47,26 @@ const (
 	OK Status = iota
 	NOK
 )
+
 func (s Status) String() string {
 	return [...]string{"OK", "NOK"}[s]
 }
 
 type MarsRover struct {
-	plateau Plateau
-	heading Direction
+	plateau  Plateau
+	heading  Direction
 	position Coordinates
-	status Status
+	status   Status
 }
 
-func (r MarsRover) turnLeft() {
-
+func (r *MarsRover) turnLeft() {
+	// [0, 1, 2, 3]
+	// [N, E, S, W]
+	newDirection := W
+	if r.heading-1 > 0 {
+		newDirection = r.heading - 1
+	}
+	r.heading = newDirection
 }
 
 func (r MarsRover) currentLocation() interface{} {
@@ -81,6 +89,12 @@ func (r MarsRover) backward() {
 
 }
 
-func (r MarsRover) turnRight() {
-
+func (r *MarsRover) turnRight() {
+	// [0, 1, 2, 3]
+	// [N, E, S, W]
+	newDirection := N
+	if r.heading < 3 {
+		newDirection = r.heading + 1
+	}
+	r.heading = newDirection
 }

--- a/go/marsroverkata/MarsRover.go
+++ b/go/marsroverkata/MarsRover.go
@@ -1,5 +1,7 @@
 package marsrover
 
+import "fmt"
+
 type Coordinates struct {
 	x int
 	y int
@@ -70,7 +72,7 @@ func (r *MarsRover) turnLeft() {
 }
 
 func (r MarsRover) currentLocation() interface{} {
-	return ""
+	return fmt.Sprintf("%d %d %s", r.position.x, r.position.y, r.heading)
 }
 
 func (r MarsRover) acceptCommands(commands []Command) {

--- a/go/marsroverkata/MarsRover.go
+++ b/go/marsroverkata/MarsRover.go
@@ -83,6 +83,21 @@ func (r MarsRover) coordinates() Coordinates {
 	return r.position
 }
 
+func (r *MarsRover) fold() {
+	if r.position.x > MaxTerrainPos {
+		r.position.x = 1
+	}
+	if r.position.x < 1 {
+		r.position.x = MaxTerrainPos
+	}
+	if r.position.y > MaxTerrainPos {
+		r.position.y = 1
+	}
+	if r.position.y < 1 {
+		r.position.y = MaxTerrainPos
+	}
+}
+
 func (r *MarsRover) forward() {
 	curr := r.position
 	switch r.heading {
@@ -97,6 +112,7 @@ func (r *MarsRover) forward() {
 	default:
 		panic("I won't know which way I am heading!!")
 	}
+	r.fold()
 }
 
 func (r *MarsRover) backward() {
@@ -113,6 +129,7 @@ func (r *MarsRover) backward() {
 	default:
 		panic("I won't know which way I am heading!!")
 	}
+	r.fold()
 }
 
 func (r *MarsRover) turnRight() {

--- a/go/marsroverkata/MarsRover.go
+++ b/go/marsroverkata/MarsRover.go
@@ -78,6 +78,10 @@ func (r MarsRover) currentLocation() interface{} {
 func (r *MarsRover) acceptCommands(commands []Command) {
 	r.showOnGrid() // Show the initial position
 	for i := range commands {
+		if r.status == NOK { //The rover will stay still is an obstacle is found
+			fmt.Println(" 💥 🚨 Obstacle ahead, aborting!!!! 🚀 ")
+			break
+		}
 		switch commands[i] {
 		case B:
 			r.backward()
@@ -90,10 +94,17 @@ func (r *MarsRover) acceptCommands(commands []Command) {
 		default:
 			panic("I don't know that command!!")
 		}
-		fmt.Println(r.position)
 		r.showOnGrid()
 	}
 
+}
+
+func (r *MarsRover) checkForObstacleCrash(c Coordinates) {
+	for i := range r.plateau.obstacles {
+		if c == r.plateau.obstacles[i].position {
+			r.status = NOK
+		}
+	}
 }
 
 func (r MarsRover) coordinates() Coordinates {
@@ -116,35 +127,45 @@ func (r *MarsRover) fold() {
 }
 
 func (r *MarsRover) forward() {
-	curr := r.position
+	curr, newPosition := r.position, r.position
+
 	switch r.heading {
 	case N:
-		r.position = Coordinates{curr.x, curr.y + 1}
+		newPosition = Coordinates{curr.x, curr.y + 1}
 	case E:
-		r.position = Coordinates{curr.x + 1, curr.y}
+		newPosition = Coordinates{curr.x + 1, curr.y}
 	case S:
-		r.position = Coordinates{curr.x, curr.y - 1}
+		newPosition = Coordinates{curr.x, curr.y - 1}
 	case W:
-		r.position = Coordinates{curr.x - 1, curr.y}
+		newPosition = Coordinates{curr.x - 1, curr.y}
 	default:
 		panic("I won't know which way I am heading!!")
+	}
+	r.checkForObstacleCrash(newPosition)
+	if r.status == OK {
+		r.position = newPosition
 	}
 	r.fold()
 }
 
 func (r *MarsRover) backward() {
-	curr := r.position
+	curr, newPosition := r.position, r.position
 	switch r.heading {
 	case N:
-		r.position = Coordinates{curr.x, curr.y - 1}
+		newPosition = Coordinates{curr.x, curr.y - 1}
 	case E:
-		r.position = Coordinates{curr.x - 1, curr.y}
+		newPosition = Coordinates{curr.x - 1, curr.y}
 	case S:
-		r.position = Coordinates{curr.x, curr.y + 1}
+		newPosition = Coordinates{curr.x, curr.y + 1}
 	case W:
-		r.position = Coordinates{curr.x + 1, curr.y}
+		newPosition = Coordinates{curr.x + 1, curr.y}
 	default:
 		panic("I won't know which way I am heading!!")
+	}
+
+	r.checkForObstacleCrash(newPosition)
+	if r.status == OK {
+		r.position = newPosition
 	}
 	r.fold()
 }
@@ -162,4 +183,5 @@ func (r *MarsRover) turnRight() {
 func (r *MarsRover) showOnGrid() {
 	CurrentGrid.UpdateRoverPosition(r.heading, r.position)
 	CurrentGrid.Draw()
+	fmt.Println()
 }

--- a/go/marsroverkata/forward_backward_test.go
+++ b/go/marsroverkata/forward_backward_test.go
@@ -7,18 +7,18 @@ import (
 )
 
 func TestSingleCommandForwardOneTileFacingNorth(t *testing.T) {
-	plateau := Plateau{maxX: 5, maxY: 5}
+	plateau := Plateau{maxX: 10, maxY: 10}
 	startingPosition := Coordinates{1, 9}
 	marsRover := MarsRover{plateau: plateau, heading: N, position: startingPosition}
 
 	marsRover.forward()
 
-	expectedPosition := Coordinates{1, 8}
+	expectedPosition := Coordinates{1, 10}
 	assert.Equal(t, expectedPosition, marsRover.coordinates())
 }
 
 func TestSingleCommandForwardOneTileFacingEast(t *testing.T) {
-	plateau := Plateau{maxX: 5, maxY: 5}
+	plateau := Plateau{maxX: 10, maxY: 10}
 	startingPosition := Coordinates{1, 9}
 	marsRover := MarsRover{plateau: plateau, heading: E, position: startingPosition}
 
@@ -29,13 +29,13 @@ func TestSingleCommandForwardOneTileFacingEast(t *testing.T) {
 }
 
 func TestSingleCommandForwardOneTileFacingSouth(t *testing.T) {
-	plateau := Plateau{maxX: 5, maxY: 5}
+	plateau := Plateau{maxX: 10, maxY: 10}
 	startingPosition := Coordinates{1, 9}
 	marsRover := MarsRover{plateau: plateau, heading: S, position: startingPosition}
 
 	marsRover.forward()
 
-	expectedPosition := Coordinates{1, 10}
+	expectedPosition := Coordinates{1, 8}
 	assert.Equal(t, expectedPosition, marsRover.coordinates())
 }
 
@@ -51,18 +51,18 @@ func TestSingleCommandForwardOneTileFacingWest(t *testing.T) {
 }
 
 func TestSingleCommandBackwardOneTileFacingNorth(t *testing.T) {
-	plateau := Plateau{maxX: 5, maxY: 5}
+	plateau := Plateau{maxX: 10, maxY: 10}
 	startingPosition := Coordinates{5, 5}
 	marsRover := MarsRover{plateau: plateau, heading: N, position: startingPosition}
 
 	marsRover.backward()
 
-	expectedPosition := Coordinates{5, 6}
+	expectedPosition := Coordinates{5, 4}
 	assert.Equal(t, expectedPosition, marsRover.coordinates())
 }
 
 func TestSingleCommandBackwardOneTileFacingEast(t *testing.T) {
-	plateau := Plateau{maxX: 5, maxY: 5}
+	plateau := Plateau{maxX: 10, maxY: 10}
 	startingPosition := Coordinates{5, 5}
 	marsRover := MarsRover{plateau: plateau, heading: E, position: startingPosition}
 
@@ -73,18 +73,18 @@ func TestSingleCommandBackwardOneTileFacingEast(t *testing.T) {
 }
 
 func TestSingleCommandBackwardOneTileFacingSouth(t *testing.T) {
-	plateau := Plateau{maxX: 5, maxY: 5}
+	plateau := Plateau{maxX: 10, maxY: 10}
 	startingPosition := Coordinates{5, 5}
 	marsRover := MarsRover{plateau: plateau, heading: S, position: startingPosition}
 
 	marsRover.backward()
 
-	expectedPosition := Coordinates{5, 4}
+	expectedPosition := Coordinates{5, 6}
 	assert.Equal(t, expectedPosition, marsRover.coordinates())
 }
 
 func TestSingleCommandBackwardOneTileFacingWest(t *testing.T) {
-	plateau := Plateau{maxX: 5, maxY: 5}
+	plateau := Plateau{maxX: 10, maxY: 10}
 	startingPosition := Coordinates{5, 5}
 	marsRover := MarsRover{plateau: plateau, heading: W, position: startingPosition}
 
@@ -106,14 +106,14 @@ func TestSingleCommandForwardOneTileFacingWestFold(t *testing.T) {
 	assert.Equal(t, expectedPosition, marsRover.coordinates())
 }
 
-func TestSingleCommandBackwardOneTileFacingWestFold(t *testing.T) {
+func TestSingleCommandBackwardOneTileFacingEastFold(t *testing.T) {
 	plateau := Plateau{maxX: 10, maxY: 10}
 	MaxTerrainPos = 10
-	startingPosition := Coordinates{10, 10}
-	marsRover := MarsRover{plateau: plateau, heading: W, position: startingPosition}
+	startingPosition := Coordinates{1, 10}
+	marsRover := MarsRover{plateau: plateau, heading: E, position: startingPosition}
 
 	marsRover.backward()
 
-	expectedPosition := Coordinates{1, 10}
+	expectedPosition := Coordinates{10, 10}
 	assert.Equal(t, expectedPosition, marsRover.coordinates())
 }

--- a/go/marsroverkata/forward_backward_test.go
+++ b/go/marsroverkata/forward_backward_test.go
@@ -1,0 +1,95 @@
+package marsrover
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSingleCommandForwardOneTileFacingNorth(t *testing.T) {
+	plateau := Plateau{maxX: 5, maxY: 5}
+	startingPosition := Coordinates{1, 9}
+	marsRover := MarsRover{plateau: plateau, heading: N, position: startingPosition}
+
+	marsRover.forward()
+
+	expectedPosition := Coordinates{1, 8}
+	assert.Equal(t, expectedPosition, marsRover.coordinates())
+}
+
+func TestSingleCommandForwardOneTileFacingEast(t *testing.T) {
+	plateau := Plateau{maxX: 5, maxY: 5}
+	startingPosition := Coordinates{1, 9}
+	marsRover := MarsRover{plateau: plateau, heading: E, position: startingPosition}
+
+	marsRover.forward()
+
+	expectedPosition := Coordinates{2, 9}
+	assert.Equal(t, expectedPosition, marsRover.coordinates())
+}
+
+func TestSingleCommandForwardOneTileFacingSouth(t *testing.T) {
+	plateau := Plateau{maxX: 5, maxY: 5}
+	startingPosition := Coordinates{1, 9}
+	marsRover := MarsRover{plateau: plateau, heading: S, position: startingPosition}
+
+	marsRover.forward()
+
+	expectedPosition := Coordinates{1, 10}
+	assert.Equal(t, expectedPosition, marsRover.coordinates())
+}
+
+func TestSingleCommandForwardOneTileFacingWest(t *testing.T) {
+	plateau := Plateau{maxX: 5, maxY: 5}
+	startingPosition := Coordinates{2, 9}
+	marsRover := MarsRover{plateau: plateau, heading: W, position: startingPosition}
+
+	marsRover.forward()
+
+	expectedPosition := Coordinates{1, 9}
+	assert.Equal(t, expectedPosition, marsRover.coordinates())
+}
+
+func TestSingleCommandBackwardOneTileFacingNorth(t *testing.T) {
+	plateau := Plateau{maxX: 5, maxY: 5}
+	startingPosition := Coordinates{5, 5}
+	marsRover := MarsRover{plateau: plateau, heading: N, position: startingPosition}
+
+	marsRover.backward()
+
+	expectedPosition := Coordinates{5, 6}
+	assert.Equal(t, expectedPosition, marsRover.coordinates())
+}
+
+func TestSingleCommandBackwardOneTileFacingEast(t *testing.T) {
+	plateau := Plateau{maxX: 5, maxY: 5}
+	startingPosition := Coordinates{5, 5}
+	marsRover := MarsRover{plateau: plateau, heading: E, position: startingPosition}
+
+	marsRover.backward()
+
+	expectedPosition := Coordinates{4, 5}
+	assert.Equal(t, expectedPosition, marsRover.coordinates())
+}
+
+func TestSingleCommandBackwardOneTileFacingSouth(t *testing.T) {
+	plateau := Plateau{maxX: 5, maxY: 5}
+	startingPosition := Coordinates{5, 5}
+	marsRover := MarsRover{plateau: plateau, heading: S, position: startingPosition}
+
+	marsRover.backward()
+
+	expectedPosition := Coordinates{5, 4}
+	assert.Equal(t, expectedPosition, marsRover.coordinates())
+}
+
+func TestSingleCommandBackwardOneTileFacingWest(t *testing.T) {
+	plateau := Plateau{maxX: 5, maxY: 5}
+	startingPosition := Coordinates{5, 5}
+	marsRover := MarsRover{plateau: plateau, heading: W, position: startingPosition}
+
+	marsRover.backward()
+
+	expectedPosition := Coordinates{6, 5}
+	assert.Equal(t, expectedPosition, marsRover.coordinates())
+}

--- a/go/marsroverkata/forward_backward_test.go
+++ b/go/marsroverkata/forward_backward_test.go
@@ -93,3 +93,27 @@ func TestSingleCommandBackwardOneTileFacingWest(t *testing.T) {
 	expectedPosition := Coordinates{6, 5}
 	assert.Equal(t, expectedPosition, marsRover.coordinates())
 }
+
+func TestSingleCommandForwardOneTileFacingWestFold(t *testing.T) {
+	plateau := Plateau{maxX: 10, maxY: 10}
+	MaxTerrainPos = 10
+	startingPosition := Coordinates{1, 9}
+	marsRover := MarsRover{plateau: plateau, heading: W, position: startingPosition}
+
+	marsRover.forward()
+
+	expectedPosition := Coordinates{10, 9}
+	assert.Equal(t, expectedPosition, marsRover.coordinates())
+}
+
+func TestSingleCommandBackwardOneTileFacingWestFold(t *testing.T) {
+	plateau := Plateau{maxX: 10, maxY: 10}
+	MaxTerrainPos = 10
+	startingPosition := Coordinates{10, 10}
+	marsRover := MarsRover{plateau: plateau, heading: W, position: startingPosition}
+
+	marsRover.backward()
+
+	expectedPosition := Coordinates{1, 10}
+	assert.Equal(t, expectedPosition, marsRover.coordinates())
+}

--- a/go/marsroverkata/go.mod
+++ b/go/marsroverkata/go.mod
@@ -1,0 +1,5 @@
+module github.com/giannoul/MarsRover-Sample-Tests/go/marsroverkata
+
+go 1.16
+
+require github.com/stretchr/testify v1.7.0 // indirect

--- a/go/marsroverkata/go.sum
+++ b/go/marsroverkata/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/marsroverkata/grid.go
+++ b/go/marsroverkata/grid.go
@@ -17,6 +17,15 @@ func NewGrid(h int, w int) *Grid {
 	return &g
 }
 
+func (g Grid) AddObstacles(obstacles []Obstacle) {
+	for i := range obstacles {
+		p := obstacles[i].position
+		// The -1 is because on slices we start counting from 0
+		g.Tiles[p.x-1][p.y-1] = "*"
+	}
+
+}
+
 func (g Grid) DrawHorizontalLine() {
 	fmt.Println("  " + strings.Repeat("----", g.Width) + "---")
 }
@@ -67,7 +76,6 @@ func (g *Grid) Draw() {
 		} else {
 			fmt.Println("|")
 		}
-
 	}
 	g.DrawHorizontalLine()
 	// draw South

--- a/go/marsroverkata/grid.go
+++ b/go/marsroverkata/grid.go
@@ -18,11 +18,11 @@ func NewGrid(h int, w int) *Grid {
 }
 
 func (g Grid) DrawHorizontalLine() {
-	fmt.Println(strings.Repeat("----", g.Width) + "---")
+	fmt.Println("  " + strings.Repeat("----", g.Width) + "---")
 }
 
 func (g Grid) DrawHorizontalNumbers() {
-	fmt.Printf("  ")
+	fmt.Printf("    ")
 	for i := 0; i < g.Width; i++ {
 		fmt.Printf(" %2d ", i+1)
 	}
@@ -44,16 +44,32 @@ func (g *Grid) initializeTiles() {
 }
 
 func (g *Grid) Draw() {
+	// draw North
+	fmt.Println(strings.Repeat(" ", g.Width*2) + "  N")
 	g.DrawHorizontalNumbers()
 	for i := 0; i < g.Height; i++ {
 		g.DrawHorizontalLine()
 		for j := 0; j < g.Width; j++ {
-			if j == 0 {
-				fmt.Printf("%2d", i+1)
+			// draw West
+			if i == (g.Height/2)-1 && j == 0 {
+				fmt.Printf("W %2d", i+1)
+			} else {
+				if j == 0 {
+					fmt.Printf("  %2d", i+1)
+				}
 			}
+
 			fmt.Printf("| %s ", g.Tiles[i][j])
 		}
-		fmt.Println("|")
+		// draw West
+		if i == (g.Height/2)-1 {
+			fmt.Println("|  E")
+		} else {
+			fmt.Println("|")
+		}
+
 	}
 	g.DrawHorizontalLine()
+	// draw South
+	fmt.Println(strings.Repeat(" ", g.Width*2) + "  S")
 }

--- a/go/marsroverkata/grid.go
+++ b/go/marsroverkata/grid.go
@@ -1,0 +1,59 @@
+package marsrover
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Grid struct {
+	Height int
+	Width  int
+	Tiles  [][]string
+}
+
+func NewGrid(h int, w int) *Grid {
+	g := Grid{Height: h, Width: w}
+	g.initializeTiles()
+	return &g
+}
+
+func (g Grid) DrawHorizontalLine() {
+	fmt.Println(strings.Repeat("----", g.Width) + "---")
+}
+
+func (g Grid) DrawHorizontalNumbers() {
+	fmt.Printf("  ")
+	for i := 0; i < g.Width; i++ {
+		fmt.Printf(" %2d ", i+1)
+	}
+	fmt.Println()
+}
+
+func (g *Grid) initializeTiles() {
+	// initialize
+	g.Tiles = make([][]string, g.Height)
+	for i := 0; i < g.Height; i++ {
+		g.Tiles[i] = make([]string, g.Width)
+	}
+	// fill with spaces
+	for i := 0; i < g.Height; i++ {
+		for j := 0; j < g.Width; j++ {
+			g.Tiles[i][j] = " "
+		}
+	}
+}
+
+func (g *Grid) Draw() {
+	g.DrawHorizontalNumbers()
+	for i := 0; i < g.Height; i++ {
+		g.DrawHorizontalLine()
+		for j := 0; j < g.Width; j++ {
+			if j == 0 {
+				fmt.Printf("%2d", i+1)
+			}
+			fmt.Printf("| %s ", g.Tiles[i][j])
+		}
+		fmt.Println("|")
+	}
+	g.DrawHorizontalLine()
+}

--- a/go/marsroverkata/grid.go
+++ b/go/marsroverkata/grid.go
@@ -7,6 +7,8 @@ import (
 
 var Markers = [4]string{"^", ">", "v", "<"}
 
+var MaxTerrainPos int
+
 type Grid struct {
 	Height int
 	Width  int
@@ -14,6 +16,7 @@ type Grid struct {
 }
 
 func NewGrid(h int, w int) *Grid {
+	MaxTerrainPos = h
 	g := Grid{Height: h, Width: w}
 	g.initializeTiles()
 	return &g

--- a/go/marsroverkata/grid.go
+++ b/go/marsroverkata/grid.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-var Markers = [4]string{"^", ">", "v", "<"}
+var Markers = [4]string{"👆", "👉", "👇", "👈"}
 
 var MaxTerrainPos = 10
 var CurrentGrid *Grid
@@ -27,7 +27,7 @@ func (g Grid) AddObstacles(obstacles []Obstacle) {
 	for i := range obstacles {
 		p := obstacles[i].position
 		// The -1 is because on slices we start counting from 0
-		g.Tiles[p.y-1][p.x-1] = "*"
+		g.Tiles[p.y-1][p.x-1] = "🚧"
 	}
 
 }
@@ -36,8 +36,8 @@ func (g Grid) UpdateRoverPosition(h Direction, p Coordinates) {
 	// Clear the previous rover position
 	for i := 0; i < g.Height; i++ {
 		for j := 0; j < g.Width; j++ {
-			if g.Tiles[i][j] == "^" || g.Tiles[i][j] == ">" || g.Tiles[i][j] == "v" || g.Tiles[i][j] == "<" {
-				g.Tiles[i][j] = " "
+			if g.Tiles[i][j] == "👆" || g.Tiles[i][j] == "👉" || g.Tiles[i][j] == "👇" || g.Tiles[i][j] == "👈" {
+				g.Tiles[i][j] = "📍"
 			}
 		}
 	}
@@ -46,13 +46,13 @@ func (g Grid) UpdateRoverPosition(h Direction, p Coordinates) {
 }
 
 func (g Grid) DrawHorizontalLine() {
-	fmt.Println("  " + strings.Repeat("----", g.Width) + "---")
+	fmt.Println("  " + strings.Repeat("-----", g.Width) + "---")
 }
 
 func (g Grid) DrawHorizontalNumbers() {
 	fmt.Printf("    ")
 	for i := 0; i < g.Width; i++ {
-		fmt.Printf(" %2d ", i+1)
+		fmt.Printf("  %2d ", i+1)
 	}
 	fmt.Println()
 }
@@ -66,7 +66,7 @@ func (g *Grid) initializeTiles() {
 	// fill with spaces
 	for i := 0; i < g.Height; i++ {
 		for j := 0; j < g.Width; j++ {
-			g.Tiles[i][j] = " "
+			g.Tiles[i][j] = "  "
 		}
 	}
 }

--- a/go/marsroverkata/grid.go
+++ b/go/marsroverkata/grid.go
@@ -73,7 +73,7 @@ func (g *Grid) initializeTiles() {
 
 func (g *Grid) Draw() {
 	// draw North
-	fmt.Println(strings.Repeat(" ", g.Width*2) + "  N")
+	fmt.Println(strings.Repeat(" ", g.Width*2) + "       N")
 
 	for i := g.Width - 1; i >= 0; i-- {
 		g.DrawHorizontalLine()
@@ -99,5 +99,5 @@ func (g *Grid) Draw() {
 	g.DrawHorizontalLine()
 	g.DrawHorizontalNumbers()
 	// draw South
-	fmt.Println(strings.Repeat(" ", g.Width*2) + "  S")
+	fmt.Println(strings.Repeat(" ", g.Width*2) + "       S")
 }

--- a/go/marsroverkata/grid.go
+++ b/go/marsroverkata/grid.go
@@ -7,7 +7,8 @@ import (
 
 var Markers = [4]string{"^", ">", "v", "<"}
 
-var MaxTerrainPos int
+var MaxTerrainPos = 10
+var CurrentGrid *Grid
 
 type Grid struct {
 	Height int
@@ -26,13 +27,22 @@ func (g Grid) AddObstacles(obstacles []Obstacle) {
 	for i := range obstacles {
 		p := obstacles[i].position
 		// The -1 is because on slices we start counting from 0
-		g.Tiles[p.x-1][p.y-1] = "*"
+		g.Tiles[p.y-1][p.x-1] = "*"
 	}
 
 }
 
 func (g Grid) UpdateRoverPosition(h Direction, p Coordinates) {
-	g.Tiles[p.x-1][p.y-1] = Markers[h]
+	// Clear the previous rover position
+	for i := 0; i < g.Height; i++ {
+		for j := 0; j < g.Width; j++ {
+			if g.Tiles[i][j] == "^" || g.Tiles[i][j] == ">" || g.Tiles[i][j] == "v" || g.Tiles[i][j] == "<" {
+				g.Tiles[i][j] = " "
+			}
+		}
+	}
+
+	g.Tiles[p.y-1][p.x-1] = Markers[h]
 }
 
 func (g Grid) DrawHorizontalLine() {
@@ -64,10 +74,10 @@ func (g *Grid) initializeTiles() {
 func (g *Grid) Draw() {
 	// draw North
 	fmt.Println(strings.Repeat(" ", g.Width*2) + "  N")
-	g.DrawHorizontalNumbers()
-	for i := 0; i < g.Height; i++ {
+
+	for i := g.Width - 1; i >= 0; i-- {
 		g.DrawHorizontalLine()
-		for j := 0; j < g.Width; j++ {
+		for j := 0; j < g.Height; j++ {
 			// draw West
 			if i == (g.Height/2)-1 && j == 0 {
 				fmt.Printf("W %2d", i+1)
@@ -79,7 +89,7 @@ func (g *Grid) Draw() {
 
 			fmt.Printf("| %s ", g.Tiles[i][j])
 		}
-		// draw West
+		// draw East
 		if i == (g.Height/2)-1 {
 			fmt.Println("|  E")
 		} else {
@@ -87,6 +97,7 @@ func (g *Grid) Draw() {
 		}
 	}
 	g.DrawHorizontalLine()
+	g.DrawHorizontalNumbers()
 	// draw South
 	fmt.Println(strings.Repeat(" ", g.Width*2) + "  S")
 }

--- a/go/marsroverkata/grid.go
+++ b/go/marsroverkata/grid.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+var Markers = [4]string{"^", ">", "v", "<"}
+
 type Grid struct {
 	Height int
 	Width  int
@@ -24,6 +26,10 @@ func (g Grid) AddObstacles(obstacles []Obstacle) {
 		g.Tiles[p.x-1][p.y-1] = "*"
 	}
 
+}
+
+func (g Grid) UpdateRoverPosition(h Direction, p Coordinates) {
+	g.Tiles[p.x-1][p.y-1] = Markers[h]
 }
 
 func (g Grid) DrawHorizontalLine() {

--- a/go/marsroverkata/grid_test.go
+++ b/go/marsroverkata/grid_test.go
@@ -1,0 +1,13 @@
+package marsrover
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGridVisualization(t *testing.T) {
+	grid := NewGrid(10, 10)
+	grid.Draw()
+	assert.Equal(t, true, true, "We want to just see the output")
+}

--- a/go/marsroverkata/grid_with_obstacles_test.go
+++ b/go/marsroverkata/grid_with_obstacles_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestGridWithObstaclesVisualization(t *testing.T) {
 	obstacles := []Obstacle{
-		Obstacle{position: Coordinates{2, 3}},
-		Obstacle{position: Coordinates{8, 8}},
+		{position: Coordinates{2, 3}},
+		{position: Coordinates{8, 8}},
 	}
 	plateau := Plateau{maxX: 5, maxY: 5, obstacles: obstacles}
 	grid := NewGrid(10, 10)

--- a/go/marsroverkata/grid_with_obstacles_test.go
+++ b/go/marsroverkata/grid_with_obstacles_test.go
@@ -1,0 +1,19 @@
+package marsrover
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGridWithObstaclesVisualization(t *testing.T) {
+	obstacles := []Obstacle{
+		Obstacle{position: Coordinates{2, 3}},
+		Obstacle{position: Coordinates{8, 8}},
+	}
+	plateau := Plateau{maxX: 5, maxY: 5, obstacles: obstacles}
+	grid := NewGrid(10, 10)
+	grid.AddObstacles(plateau.obstacles)
+	grid.Draw()
+	assert.Equal(t, true, true, "We want to just see the output")
+}

--- a/go/marsroverkata/grid_with_rover_test.go
+++ b/go/marsroverkata/grid_with_rover_test.go
@@ -1,0 +1,22 @@
+package marsrover
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGridWithRoverVisualization(t *testing.T) {
+	plateau := Plateau{maxX: 5, maxY: 5}
+	startingPosition := Coordinates{1, 2}
+	marsRover := MarsRover{plateau: plateau, heading: N, position: startingPosition}
+
+	grid := NewGrid(10, 10)
+	grid.UpdateRoverPosition(marsRover.heading, marsRover.position)
+	grid.Draw()
+
+	marsRover.turnRight()
+	grid.UpdateRoverPosition(marsRover.heading, marsRover.position)
+	grid.Draw()
+	assert.Equal(t, true, true, "We want to just see the output")
+}

--- a/go/marsroverkata/rotate_right_test.go
+++ b/go/marsroverkata/rotate_right_test.go
@@ -1,0 +1,27 @@
+package marsrover
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCanRotateRight1(t *testing.T) {
+	plateau := Plateau{maxX: 5, maxY: 5}
+	startingPosition := Coordinates{1, 2}
+	marsRover := MarsRover{plateau: plateau, heading: N, position: startingPosition}
+
+	marsRover.turnRight()
+
+	assert.Equal(t, E, marsRover.heading)
+}
+
+func TestCanRotateRight2(t *testing.T) {
+	plateau := Plateau{maxX: 5, maxY: 5}
+	startingPosition := Coordinates{1, 2}
+	marsRover := MarsRover{plateau: plateau, heading: W, position: startingPosition}
+
+	marsRover.turnRight()
+
+	assert.Equal(t, N, marsRover.heading)
+}

--- a/go/marsroverkata/rover_with_obstacles_test.go
+++ b/go/marsroverkata/rover_with_obstacles_test.go
@@ -1,0 +1,48 @@
+package marsrover
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoverWithObstacles(t *testing.T) {
+	obstacles := []Obstacle{
+		{position: Coordinates{2, 3}},
+		{position: Coordinates{8, 8}},
+		{position: Coordinates{9, 2}},
+	}
+	plateau := Plateau{maxX: 10, maxY: 10, obstacles: obstacles}
+	startingPosition := Coordinates{1, 2}
+	marsRover := MarsRover{plateau: plateau, heading: N, position: startingPosition}
+
+	CurrentGrid = NewGrid(10, 10)
+	CurrentGrid.AddObstacles(plateau.obstacles)
+
+	commands := []Command{B, F, L, F, F, R}
+	marsRover.acceptCommands(commands)
+
+	assert.Equal(t, "10 2 W", marsRover.currentLocation())
+}
+
+func TestRoverWithMoreObstacles(t *testing.T) {
+	obstacles := []Obstacle{
+		{position: Coordinates{2, 3}},
+		{position: Coordinates{8, 8}},
+		{position: Coordinates{9, 2}},
+		{position: Coordinates{5, 5}},
+		{position: Coordinates{6, 8}},
+		{position: Coordinates{4, 2}},
+	}
+	plateau := Plateau{maxX: 10, maxY: 10, obstacles: obstacles}
+	startingPosition := Coordinates{1, 2}
+	marsRover := MarsRover{plateau: plateau, heading: N, position: startingPosition}
+
+	CurrentGrid = NewGrid(10, 10)
+	CurrentGrid.AddObstacles(plateau.obstacles)
+
+	commands := []Command{B, F, L, F, R, F, F, F, L, F, F, F, F, F, F, F, B}
+	marsRover.acceptCommands(commands)
+
+	assert.Equal(t, "6 5 W", marsRover.currentLocation())
+}

--- a/go/marsroverkata/sample2_test.go
+++ b/go/marsroverkata/sample2_test.go
@@ -2,17 +2,22 @@ package marsrover
 
 import (
 	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestReceiveSingleCommandShouldMove(t *testing.T) {
 	plateau := Plateau{maxX: 5, maxY: 5}
-	startingPosition := Coordinates{1,9}
+	startingPosition := Coordinates{1, 9}
 	marsRover := MarsRover{plateau: plateau, heading: N, position: startingPosition}
+	CurrentGrid = NewGrid(10, 10)
+	//grid.UpdateRoverPosition(marsRover.heading, marsRover.position)
+	//grid.Draw()
 
 	commands := []Command{B}
 	marsRover.acceptCommands(commands)
-
-	expectedPosition := Coordinates{1,8}
+	//grid.UpdateRoverPosition(marsRover.heading, marsRover.coordinates())
+	//grid.Draw()
+	expectedPosition := Coordinates{1, 8}
 	assert.Equal(t, expectedPosition, marsRover.coordinates())
 }

--- a/go/marsroverkata/sample3_test.go
+++ b/go/marsroverkata/sample3_test.go
@@ -1,17 +1,19 @@
 package marsrover
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFollowInstructions(t *testing.T) {
-	plateau := Plateau{maxX: 5, maxY: 5}
-	startingPosition := Coordinates{1,2}
+	plateau := Plateau{maxX: 10, maxY: 10}
+	startingPosition := Coordinates{1, 2}
 	marsRover := MarsRover{plateau: plateau, heading: N, position: startingPosition}
+	CurrentGrid = NewGrid(10, 10)
 
 	commands := []Command{B, F, L, F, F, R}
 	marsRover.acceptCommands(commands)
 
-	assert.Equal(t, "-1 2 N", marsRover.currentLocation())
+	assert.Equal(t, "9 2 N", marsRover.currentLocation())
 }

--- a/go/marsroverkata/sample5_test.go
+++ b/go/marsroverkata/sample5_test.go
@@ -1,13 +1,14 @@
 package marsrover
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFollowAllInstructions(t *testing.T) {
 	plateau := Plateau{maxX: 5, maxY: 5}
-	startingPosition := Coordinates{1,2}
+	startingPosition := Coordinates{1, 2}
 	marsRover := MarsRover{plateau: plateau, heading: N, position: startingPosition}
 
 	commands := []Command{B, F, L, F, F, R}
@@ -23,7 +24,7 @@ func TestFollowAllInstructions(t *testing.T) {
 			marsRover.turnRight()
 		}
 	}
-	expectedPosition := Coordinates{-1,2}
+	expectedPosition := Coordinates{9, 2}
 	assert.Equal(t, expectedPosition, marsRover.coordinates())
 	assert.Equal(t, N, marsRover.heading)
 }


### PR DESCRIPTION
Following the details [here](https://katalyst.codurance.com/mars-rover) the solutions has the following details:
* the grid is 10 x 10
* when the rover gets on the grid's edges it will fold. For example, if we move one step forward from the position `10 1 E` we will go to `1 1 E`
* no negative positions exist (like e.g in the original [sample5_test.go](https://github.com/emilybache/MarsRover-Sample-Tests/blob/main/go/marsroverkata/sample5_test.go#L26))
* if an obstacle is found, the rover will stop prior colliding and will not accept any more commands 

For the presentation requirements:

```
ilias@CSMachine:[~/GitCode/MarsRover-Sample-Tests/go/marsroverkata]: go test -v -run TestGridWithRoverVisualization
ilias@CSMachine:[~/GitCode/MarsRover-Sample-Tests/go/marsroverkata]: go test -v -run TestGridWithObstaclesVisualization
ilias@CSMachine:[~/GitCode/MarsRover-Sample-Tests/go/marsroverkata]: go test -v -run TestRoverWithObstacles
ilias@CSMachine:[~/GitCode/MarsRover-Sample-Tests/go/marsroverkata]: go test -v -run TestRoverWithMoreObstacles
```